### PR TITLE
Added support for retaining native subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ A minimal example to decrypt and extract some files might look like:
 from iphone_backup_decrypt import EncryptedBackup, RelativePath, RelativePathsLike
 
 passphrase = "..."  # Or load passphrase more securely from stdin, or a file, etc.
-backup_path = "%AppData%\\Apple Computer\\MobileSync\\Backup\\[device-specific-hash]"
+backup_path = "%AppData%\\Apple Computer\\MobileSync\\Backup\\[device-specific-hash]" # use backslashes for Windows or forward slashes for Mac/Linux
 
 backup = EncryptedBackup(backup_directory=backup_path, passphrase=passphrase)
+
+# Extract entire file contents while preserving relative paths
+backup.extract_files(relative_paths_like="%", output_folder="./output")
 
 # Extract the call history SQLite database:
 backup.extract_file(relative_path=RelativePath.CALL_HISTORY, 

--- a/src/iphone_backup_decrypt/iphone_backup.py
+++ b/src/iphone_backup_decrypt/iphone_backup.py
@@ -282,11 +282,24 @@ class EncryptedBackup:
         # Ensure output destination exists then loop through matches:
         os.makedirs(output_folder, exist_ok=True)
         for file_id, matched_relative_path, file_bplist in results:
-            filename = os.path.basename(matched_relative_path)
-            output_path = os.path.join(output_folder, filename)
+            output_path = os.path.join(output_folder, matched_relative_path).replace("/","\\") # assumes Windows convention
+            # Reconstruct path to avoid invalid path errors, replacing forbidden characters when encountered
+            output_path_elements = output_path.split(":",1)
+            output_path = output_path_elements[0] + ":" + output_path_elements[1].replace(":","-")
+            output_path = output_path.replace("*","-")
+            output_path = output_path.replace("|","-")
+            output_path = output_path.replace("?","-")
+            output_path = output_path.replace("\"","-")
+            output_path = output_path.replace("<","-")
+            output_path = output_path.replace(">","-")
+            # Make directories if they don't already exist
+            output_path_parent = output_path.rsplit("\\", 1)[0]
+            if not os.path.exists(output_path_parent): 
+                os.makedirs(output_path_parent)
             # Decrypt the file:
             decrypted_data = self._decrypt_inner_file(file_id=file_id, file_bplist=file_bplist)
             # Output to disk:
             if decrypted_data is not None:
                 with open(output_path, 'wb') as outfile:
                     outfile.write(decrypted_data)
+                print("Saved:", output_path)


### PR DESCRIPTION
Hello! I modified your code slightly in iphone_backup.py so that it retains native device subfolders when saving files found. For example, suppose you did: 

`backup.extract_file(relative_path="%", output_path="C:\\your\path\here")`

It would add all the files to the output path, but lose all the subdirectory structure from the source. This new version allows it to retain the subdirectory structure. It also avoids forbidden paths by replacing forbidden characters. 

I found this new feature very helpful; hoping you do too. :)