### PR TITLE
Add extraction of (locally stored) iCloud Photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ backup.extract_file(relative_path=RelativePath.CALL_HISTORY,
 # Extract the camera roll, using MatchFiles for combined path and domain matching:
 backup.extract_files(**MatchFiles.CAMERA_ROLL, output_folder="./output/camera_roll")
 
+# Extract iCloud Photos that are stored locally in the backup (there may be some
+# duplication with the camera roll)
+backup.extract_files(**MatchFiles.ICLOUD_PHOTOS, output_folder="./output/icloud_photos")
+
 # Extract WhatsApp SQLite database and attachments:
 backup.extract_file(relative_path=RelativePath.WHATSAPP_MESSAGES,
                     output_filename="./output/whatsapp.sqlite")

--- a/src/iphone_backup_decrypt/iphone_backup.py
+++ b/src/iphone_backup_decrypt/iphone_backup.py
@@ -37,6 +37,7 @@ class RelativePathsLike:
 
     # Standard iOS file locations:
     CAMERA_ROLL = "Media/DCIM/%APPLE/IMG%.%"
+    ICLOUD_PHOTOS = "Media/PhotoData/CPLAssets/group%/%.%"
     SMS_ATTACHMENTS = "Library/SMS/Attachments/%.%"
     VOICEMAILS = "Library/Voicemail/%.amr"
     VOICE_RECORDINGS = "Library/Recordings/%"
@@ -69,6 +70,7 @@ class MatchFiles:
     """
 
     CAMERA_ROLL = {"relative_paths_like": RelativePathsLike.CAMERA_ROLL, "domain_like": DomainLike.CAMERA_ROLL}
+    ICLOUD_PHOTOS = {"relative_paths_like": RelativePathsLike.ICLOUD_PHOTOS, "domain_like": DomainLike.CAMERA_ROLL}
     CHROME_DOWNLOADS = {"relative_paths_like": "Documents/%", "domain_like": "AppDomain-com.google.chrome.ios"}
     STRAVA_WORKOUTS = {"relative_paths_like": "Documents/%.fit", "domain_like": "AppDomain-com.strava.stravaride"}
     WHATSAPP_ATTACHMENTS = {"relative_paths_like": RelativePathsLike.WHATSAPP_ATTACHMENTS,


### PR DESCRIPTION
Thanks for this fantastic script, it works great!

I noticed when browsing the output for a few devices that only a subset of photos from the devices' camera rolls were being provided. All these devices use iCloud Photos, and it looks like photos are split between `Media/DCIM/` and `Media/PhotoData/CPLAssets/` when this is the case.

I've added ICLOUD_PHOTOS to `RelativePathsLike` and `MatchFiles` in this PR, with example usage in the README - during testing I was seeing combined file counts across the `camera_roll` and `icloud_photos` output folders being higher than the media counts reported by the devices in their Photos apps - so there's likely media duplication within the data extracted from the DCIM and CPLAssets folders, but probably better to over provide and let the user de-duplicate as required?