### PR TITLE
Make relative_paths_like Optional and Allow Custom Decryption Chunk Size

### DIFF
--- a/src/iphone_backup_decrypt/iphone_backup.py
+++ b/src/iphone_backup_decrypt/iphone_backup.py
@@ -269,7 +269,7 @@ class EncryptedBackup:
         # Decrypt the requested file:
         self._decrypt_file_to_disk(file_id=file_id, file_plist=file_plist, key=inner_key, output_filepath=output_filename)
 
-    def extract_files(self, *, relative_paths_like, domain_like=None, output_folder,
+    def extract_files(self, *, relative_paths_like=None, domain_like=None, output_folder,
                       preserve_folders=False, domain_subfolders=False, incremental=False,
                       filter_callback=None):
         """
@@ -279,15 +279,17 @@ class EncryptedBackup:
         but using 'preserve_folders' and 'domain_subfolders' may mitigate this.
 
         :param relative_paths_like:
-            An iOS 'relativePath' of the files to be decrypted, containing '%' or '_' SQL LIKE wildcards.
+            Optional. An iOS 'relativePath' of the files to be decrypted, containing '%' or '_' SQL LIKE wildcards.
             Common relative path wildcards are provided by the 'RelativePathsLike' class, otherwise these can be found
             by opening the decrypted Manifest.db file and examining the Files table.
+            One of relative_paths_like or domain_like must be provided.
         :param domain_like:
             Optional. An iOS 'domain' for the files to be decrypted, containing '%' or '_' SQL LIKE wildcards.
             If a domain is provided, only files from that domain will be extracted, which can be useful for non-unique
             relative paths.
             Common domain wildcards are provided by the 'DomainLike' class, otherwise these can be found by opening the
             decrypted Manifest.db file and examining the Files table.
+            One of relative_paths_like or domain_like must be provided.
         :param output_folder:
             The folder to write output files into. Files will be named with their internal iOS filenames and will
             overwrite anything in the output folder with that name.

--- a/src/iphone_backup_decrypt/utils.py
+++ b/src/iphone_backup_decrypt/utils.py
@@ -7,7 +7,7 @@ __all__ = ["RelativePath", "RelativePathsLike", "DomainLike", "MatchFiles", "Fil
 
 
 _CBC_BLOCK_SIZE = 16  # bytes.
-_CHUNK_SIZE = 100 * 1024**2  # 100MB blocks, must be a multiple of 16 bytes.
+_CHUNK_SIZE = 1024**2  # 1MB blocks, must be a multiple of 16 bytes.
 
 
 class RelativePath:


### PR DESCRIPTION
This PR makes two changes:

### Make `relative_paths_like` Optional
Based on the validation logic in the `extract_files` function:
```python
# Check the provided arguments and replace missing ones with wildcards:
if relative_paths_like is None and domain_like is None:
    # If someone _really_ wants to try and extract everything, then setting both to '%' should be enough.
    raise ValueError("At least one of 'relative_paths_like' or 'domain_like' must be specified!")
elif relative_paths_like is None and domain_like is not None:
    relative_paths_like = "%"
elif relative_paths_like is not None and domain_like is None:
    domain_like = "%"
```
The `relative_paths_like` parameter appears to be optional (at least it seems to me that). Thus, it should be set to None by default.

### Allow Custom Decryption Chunk Size
I found the default chunk size (100MB) drives the decryption process very slow, especially when dealing with a lot of WhatsApp media files. Therefore, a parameter has been added to the `EncryptedBackup` class for adjusting the chunk size.
